### PR TITLE
chore: add release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,20 @@
+name: release-please
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: php
+          package-name: ai_content_summary


### PR DESCRIPTION
## Summary
- add workflow using google's release-please action to automate tagged releases

## Testing
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_b_68bb88a45228832f9eaac30b6db2f8c9