### PR TITLE
Remove manual summary truncation

### DIFF
--- a/src/Service/AiSummaryService.php
+++ b/src/Service/AiSummaryService.php
@@ -80,11 +80,6 @@ class AiSummaryService {
       $response = $provider->chat($messages, $settings['model_id'])->getNormalized();
       $summary = $response->getText();
 
-      // Ensure summary is within length limits.
-      if (strlen($summary) > $max_length) {
-        $summary = substr($summary, 0, $max_length - 3) . '...';
-      }
-
       return trim($summary);
     }
     catch (\Exception $e) {


### PR DESCRIPTION
## Summary
- remove substring truncation in summary generation

## Testing
- `php -l src/Service/AiSummaryService.php`
- `composer validate --no-check-all --strict`


------
https://chatgpt.com/codex/tasks/task_b_68c0277cfea0832f8957826de6bc1e7d